### PR TITLE
HC-35: ZAP security setup and Nginx header fixes

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           target: 'https://staging.092024-bleu-3.wns.wilders.dev/'
           fail_action: true
-          artifact_name: zap_${{ github.run_id }}
+          artifact_name: zap-report
 
 
   deploy-main:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -91,7 +91,7 @@ jobs:
   zap-scan:
     needs: [deploy-server, deploy-client]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/zap-security'
     steps:
       - name: Run OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.10.0

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKER_HUB_CLIENT_IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}
 
   zap-scan:
-    needs: [deploy-server, deploy-client]
+    # needs: [deploy-server, deploy-client]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/zap-security'
     steps:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -98,7 +98,8 @@ jobs:
         with:
           target: 'https://staging.092024-bleu-3.wns.wilders.dev/'
           fail_action: true
-          artifact_name: report
+          artifact_name: zap_${{ github.run_id }}
+
 
   deploy-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -91,7 +91,7 @@ jobs:
   zap-scan:
     # needs: [deploy-server, deploy-client]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/zap-security'
+    if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/HC-35/zap-security'
     steps:
       - name: Run OWASP ZAP Baseline Scan
         uses: zaproxy/action-baseline@v0.10.0

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -94,13 +94,11 @@ jobs:
     if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/HC-35/zap-security'
     steps:
       - name: Run OWASP ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.10.0
+        uses: zaproxy/action-baseline@v0.7.0
         with:
           target: 'https://staging.092024-bleu-3.wns.wilders.dev/'
           fail_action: true
-          artifact_name: zap-report
-
-
+         
   deploy-main:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           target: 'https://staging.092024-bleu-3.wns.wilders.dev/'
           fail_action: true
+          cmd_options: "-I"  # Fail sur MEDIUM et HIGH seulement
          
   deploy-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -94,7 +94,7 @@ jobs:
     if: github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/HC-35/zap-security'
     steps:
       - name: Run OWASP ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.7.0
+        uses: zaproxy/action-baseline@v0.14.0
         with:
           target: 'https://staging.092024-bleu-3.wns.wilders.dev/'
           fail_action: true

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,26 @@ http {
     server {
         listen 80;
 
+         # Security Headers
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-src 'none';" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+        server_tokens off;  # show off the server version
+
+        # Specific headers for robots.txt and sitemap.xml
+        location = /robots.txt {
+            proxy_pass http://frontend:5173/robots.txt;
+            add_header X-Frame-Options "DENY" always;
+            add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none'" always;
+        }
+        location = /sitemap.xml {
+            proxy_pass http://frontend:5173/sitemap.xml;
+            add_header X-Frame-Options "DENY" always;
+            add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none'" always;
+        }
+
         location /api {
             proxy_pass http://backend:4000/graphql;
 


### PR DESCRIPTION
⚠️ ZAP is configured without `needs` and still runs on HC-35 branch for testing. 
Once merged into dev, **uncomment** `needs: [deploy-server, deploy-client]` **and remove** the condition `|| github.ref == 'refs/heads/HC-35/zap-security'` so the scan runs only on staging after deployments.”

- Set up OWASP ZAP in the CI workflow using a more stable version (v0.14.0)
- Fixed ZAP scan medium errors by adding the required security headers in the Nginx configuration (CSP, anti-clickjacking, etc.)